### PR TITLE
Add crates/docs badges to finder_info readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # finderinfo
 
+![docs.rs](https://img.shields.io/docsrs/finder_info) ![Crates.io Version](https://img.shields.io/crates/v/finder_info)
+
 A library to parse Apple HFS/HFS+/APFS FinderInfo attribute.
 
 On modern MacOS systems, objects in the filesystem can have an extended attribute called `com.apple.FinderInfo`. This


### PR DESCRIPTION
Couldn't find the docs for this crate briefly because of the naming difference between the repo and crates.io, this should help 😃 